### PR TITLE
Remove deprecated usage of django.conf.urls.patterns

### DIFF
--- a/jsonrpc/tests/test_backend_django/urls.py
+++ b/jsonrpc/tests/test_backend_django/urls.py
@@ -1,8 +1,7 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from jsonrpc.backend.django import api
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'', include(api.urls)),
     url(r'prefix', include(api.urls)),
-)
+]


### PR DESCRIPTION
https://stackoverflow.com/questions/34108321/new-url-format-in-django-1-9