### PR TITLE
Fix missing super call to Django test case

### DIFF
--- a/jsonrpc/tests/test_backend_django/tests.py
+++ b/jsonrpc/tests/test_backend_django/tests.py
@@ -18,6 +18,7 @@ class TestDjangoBackend(TestCase):
     def setUpClass(cls):
         os.environ['DJANGO_SETTINGS_MODULE'] = \
             'jsonrpc.tests.test_backend_django.settings'
+        super(TestDjangoBackend, cls).setUpClass()
 
     def test_urls(self):
         self.assertTrue(isinstance(api.urls, list))


### PR DESCRIPTION
See https://stackoverflow.com/questions/29653129/update-to-django-1-8-attributeerror-django-test-testcase-has-no-attribute-cl